### PR TITLE
bug fixed: 文章标题末尾的d被去除

### DIFF
--- a/m2w/rest_api/create.py
+++ b/m2w/rest_api/create.py
@@ -61,7 +61,7 @@ def _create_article(self, md_path, post_metadata) -> None:
 
     # 5 构造上传的请求内容
     post_data = {
-        "title": filename.strip(".md"),
+        "title": filename.split(".md")[0],
         "content": str(post_content_html, encoding="utf-8"),
         "status": post_metadata["status"],
         "comment_status": "open",

--- a/m2w/rest_api/rest_api.py
+++ b/m2w/rest_api/rest_api.py
@@ -85,7 +85,7 @@ class RestApi:
             else:
                 print(f"The post {new_md} is updating")
                 if (
-                    os.path.basename(new_md).strip(".md")
+                    os.path.basename(new_md).split('.md')[0]
                     in self.article_title_dict.keys()
                 ):
                     _update_article(

--- a/m2w/rest_api/rest_api.py
+++ b/m2w/rest_api/rest_api.py
@@ -63,7 +63,7 @@ class RestApi:
         for new_md in md_create:
             if not force_upload:
                 if (
-                    os.path.basename(new_md).strip(".md")
+                    os.path.basename(new_md).split('.md')[0]
                     in self.article_title_dict.keys()
                 ):
                     if verbose:

--- a/m2w/upload.py
+++ b/m2w/upload.py
@@ -27,9 +27,7 @@ def make_post(filepath, metadata):
     """
     filename = os.path.basename(filepath)  # 例如：test(2021.11.19).md
     filename_suffix = filename.split('.')[-1]  # 例如：md
-    filename_prefix = filename.strip(
-        ".md"
-    )  # 例如：test(2021.11.19)
+    filename_prefix = filename.split('.md')[0]  # 例如：test(2021.11.19)
 
     # 目前只支持 .md 后缀的文件
     if filename_suffix != 'md':


### PR DESCRIPTION
问题描述：
https://blognas.hwb0307.com/other/6093
在nextcloud的系列文章中发现标题末尾的d没有了

询问博主后是去除文件名后缀'.md'时被一并去除了
https://github.com/huangwb8/m2w/blob/7fb6907482931addee36d472fd628c8a516a73ba/m2w/upload.py#L30
经过排查，应为使用python的str.strip('.md')时将末尾的（潜在还有标题首的）'m'和'd'一并去除

这个pr用split('.md')[0]的方式代替了str.strip()，但修正代码后，可能还是需要人工修改博客上文章的标题。
