### PR TITLE
Fix duplicate upload issue for special character filenames

### DIFF
--- a/m2w/rest_api/rest_api.py
+++ b/m2w/rest_api/rest_api.py
@@ -8,7 +8,7 @@ import os
 import asyncio
 import base64
 
-from .articles import get_all_articles
+from .articles import get_all_articles, normalize_title
 from .tags import get_all_tags
 from .categories import get_all_categories
 from .update import _update_article
@@ -61,11 +61,9 @@ class RestApi:
         ) if not force_upload else print("You want a force uploading? Great!")
 
         for new_md in md_create:
+            filename_prefix = normalize_title(os.path.splitext(os.path.basename(new_md))[0])
             if not force_upload:
-                if (
-                    os.path.basename(new_md).split('.md')[0]
-                    in self.article_title_dict.keys()
-                ):
+                if filename_prefix in self.article_title_dict:
                     if verbose:
                         print(
                             f'Warning: The post {new_md} is existed in your WordPress site. Ignore uploading!'
@@ -84,10 +82,7 @@ class RestApi:
                         print(f"The post {new_md} uploads successful!")
             else:
                 print(f"The post {new_md} is updating")
-                if (
-                    os.path.basename(new_md).split('.md')[0]
-                    in self.article_title_dict.keys()
-                ):
+                if filename_prefix in self.article_title_dict:
                     _update_article(
                         self,
                         md_path=new_md,
@@ -102,10 +97,8 @@ class RestApi:
                     )
                 print(f"The post {new_md} uploads successful!")
         for legacy_md in md_update:
-            filename_prefix = os.path.splitext(os.path.basename(legacy_md))[0]
-            if (
-                filename_prefix in self.article_title_dict.keys()
-            ):
+            filename_prefix = normalize_title(os.path.splitext(os.path.basename(legacy_md))[0])
+            if filename_prefix in self.article_title_dict:
                 _update_article(
                     self,
                     md_path=legacy_md,


### PR DESCRIPTION
## 修复说明

修复了包含特殊字符的 Markdown 文件名导致的重复上传问题。

## 主要修改

### 1. 新增标题标准化函数 (`m2w/rest_api/articles.py`)

- 新增 `normalize_title()` 函数，对标题执行以下标准化处理：
  - HTML 反解码（`unescape`）
  - Unicode NFKC 归一化
  - 常见引号/横线映射（全角转半角等）
  - 连续符号压缩与空白折叠

### 2. 更新文章存在性检查逻辑 (`m2w/rest_api/rest_api.py`)

- 引入 `normalize_title` 参与新文稿与历史文稿判断
- 替换原有的 `basename().split('.md')[0]` 直接比较逻辑
- 修复因全角符号或 HTML 实体导致的重复上传

## 代码变更详情

### `m2w/rest_api/articles.py`
- 新增导入：`from html import unescape`, `import unicodedata`, `import re`
- 新增 `_TITLE_TRANS_TABLE` 字符映射表
- 新增 `normalize_title()` 函数
- 修改 `__article_title_request()` 中的标题处理逻辑

### `m2w/rest_api/rest_api.py`
- 导入 `normalize_title` 函数
- 修改 `upload_article()` 方法中的文件名比较逻辑

## 测试验证

- 手动准备仅含 6 个特殊文件名的 `_posts` 目录
- 连续多次运行 `python myblog.py`（每次使用全新 `path_legacy_json`）
- 结果均输出 "Warning: ... is existed... Ignore uploading!" 且不再重复上传
- 验证修复有效

## 影响范围

- ✅ 修复重复上传问题
- ✅ 提高文件存在性检查的准确性  
- ✅ 不影响现有功能
- ✅ 向后兼容

## 代码变更

### 新增文件
- 无

### 修改文件
- `m2w/rest_api/articles.py`: 新增 `normalize_title()` 函数和相关映射表
- `m2w/rest_api/rest_api.py`: 更新文章存在性检查逻辑

### 删除文件
- 无