### PR TITLE
fix: 修复 REST API 模式下文章更新时无限重试问题

### DIFF
--- a/m2w/rest_api/articles.py
+++ b/m2w/rest_api/articles.py
@@ -11,6 +11,7 @@ import asyncio
 from html import unescape
 import unicodedata
 import re
+from .utils import DEFAULT_TIMEOUT
 
 
 _TITLE_TRANS_TABLE = str.maketrans({
@@ -65,11 +66,14 @@ async def get_all_articles(self, verbose) -> None:
     """
     获取所有的文章信息
     """
-    article_num = httpx.get(self.url + "wp-json/wp/v2/posts?page=1&per_page=1").headers[
+    article_num = httpx.get(
+        self.url + "wp-json/wp/v2/posts?page=1&per_page=1",
+        timeout=DEFAULT_TIMEOUT,
+    ).headers[
         'x-wp-total'
     ]
     page_num = math.ceil(float(article_num) / 30.0)
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
         task_list = []
         for num in range(1, page_num + 1):
             req = __article_title_request(self, client, num)

--- a/m2w/rest_api/categories.py
+++ b/m2w/rest_api/categories.py
@@ -5,25 +5,29 @@
 # @FileName: categories.py
 # @Software: PyCharm
 
+import asyncio
 import httpx
 import math
-import asyncio
+
+from .utils import format_wp_error, register_taxonomy_alias
+
+
+def _cache_category_aliases(store, payload) -> None:
+    category_id = int(payload["id"])
+    register_taxonomy_alias(store, category_id, payload.get("name"), payload.get("slug"))
 
 
 async def __categories_request(self, client: httpx.AsyncClient(), page_num: int):
     resp = await client.get(
         self.url + f"wp-json/wp/v2/categories?page={page_num}&per_page=30"
     )
-    try:
-        assert (
-            resp.status_code == 200
-        ), "Error when requiring category lists. Pleas try later!"
-    except AssertionError as e:
-        print("Reminder from m2w: " + str(e))
-        raise AssertionError
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Error when requiring category lists: {format_wp_error(resp)}"
+        )
 
-    for categories in resp.json():
-        self.categories_dict[categories["name"]] = int(categories["id"])
+    for category in resp.json():
+        _cache_category_aliases(self.categories_dict, category)
 
 
 async def get_all_categories(self, verbose) -> None:
@@ -31,7 +35,7 @@ async def get_all_categories(self, verbose) -> None:
     获取所有的类别信息
     """
     categories_num = httpx.get(
-        self.url + "wp-json/wp/v2/tags?page=1&per_page=1"
+        self.url + "wp-json/wp/v2/categories?page=1&per_page=1"
     ).headers['x-wp-total']
     page_num = math.ceil(float(categories_num) / 30.0)
     async with httpx.AsyncClient() as client:
@@ -52,16 +56,30 @@ def create_category(self, category_name: str) -> int:
     @param category_name: 类别名
     @return: 创建category的id
     """
-    try:
-        resp = httpx.post(
-            url=self.url + "wp-json/wp/v2/categories",
-            headers=self.wp_header,
-            json={"name": category_name},
-        )
-        assert (
-            resp.status_code == 201
-        ), f"Category created failed. Please try again! Messages: {resp.json()['message']}"
-        self.categories_dict[category_name] = resp.json()['id']
-        return resp.json()['id']
-    except AssertionError as e:
-        print("Reminder from m2w: " + str(e))
+    resp = httpx.post(
+        url=self.url + "wp-json/wp/v2/categories",
+        headers=self.wp_header,
+        json={"name": category_name},
+    )
+    if resp.status_code == 201:
+        payload = resp.json()
+        category_id = int(payload['id'])
+        _cache_category_aliases(self.categories_dict, payload)
+        register_taxonomy_alias(self.categories_dict, category_id, category_name)
+        return category_id
+
+    if resp.status_code == 400:
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict) and payload.get("code") == "term_exists":
+            term_id = payload.get("data", {}).get("term_id")
+            if term_id is not None:
+                term_id = int(term_id)
+                register_taxonomy_alias(self.categories_dict, term_id, category_name)
+                return term_id
+
+    raise RuntimeError(
+        f"Category created failed: {format_wp_error(resp)}"
+    )

--- a/m2w/rest_api/categories.py
+++ b/m2w/rest_api/categories.py
@@ -10,6 +10,7 @@ import httpx
 import math
 
 from .utils import format_wp_error, register_taxonomy_alias
+from .utils import DEFAULT_TIMEOUT
 
 
 def _cache_category_aliases(store, payload) -> None:
@@ -35,10 +36,11 @@ async def get_all_categories(self, verbose) -> None:
     获取所有的类别信息
     """
     categories_num = httpx.get(
-        self.url + "wp-json/wp/v2/categories?page=1&per_page=1"
+        self.url + "wp-json/wp/v2/categories?page=1&per_page=1",
+        timeout=DEFAULT_TIMEOUT,
     ).headers['x-wp-total']
     page_num = math.ceil(float(categories_num) / 30.0)
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
         task_list = []
         for num in range(1, page_num + 1):
             req = __categories_request(self, client, num)
@@ -60,6 +62,7 @@ def create_category(self, category_name: str) -> int:
         url=self.url + "wp-json/wp/v2/categories",
         headers=self.wp_header,
         json={"name": category_name},
+        timeout=DEFAULT_TIMEOUT,
     )
     if resp.status_code == 201:
         payload = resp.json()

--- a/m2w/rest_api/create.py
+++ b/m2w/rest_api/create.py
@@ -7,7 +7,7 @@
 
 from .tags import create_tag
 from .categories import create_category
-from .utils import lookup_taxonomy_id, ensure_wp_success
+from .utils import lookup_taxonomy_id, ensure_wp_success, DEFAULT_TIMEOUT
 import frontmatter
 import markdown
 import os
@@ -74,5 +74,6 @@ def _create_article(self, md_path, post_metadata) -> None:
         url=self.url + "wp-json/wp/v2/posts",
         headers=self.wp_header,
         json=post_data,
+        timeout=DEFAULT_TIMEOUT,
     )
     ensure_wp_success(resp, f"File {md_path} uploaded")

--- a/m2w/rest_api/tags.py
+++ b/m2w/rest_api/tags.py
@@ -10,6 +10,7 @@ import httpx
 import math
 
 from .utils import format_wp_error, register_taxonomy_alias
+from .utils import DEFAULT_TIMEOUT
 
 
 def _cache_tag_aliases(store, payload) -> None:
@@ -32,11 +33,14 @@ async def get_all_tags(self, verbose) -> None:
     """
     获取所有的标签信息
     """
-    tags_num = httpx.get(self.url + "wp-json/wp/v2/tags?page=1&per_page=1").headers[
+    tags_num = httpx.get(
+        self.url + "wp-json/wp/v2/tags?page=1&per_page=1",
+        timeout=DEFAULT_TIMEOUT,
+    ).headers[
         'x-wp-total'
     ]
     page_num = math.ceil(float(tags_num) / 30.0)
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
         task_list = []
         for num in range(1, page_num + 1):
             req = __tags_request(self, client, num)
@@ -58,6 +62,7 @@ def create_tag(self, tag_name: str) -> int:
         url=self.url + "wp-json/wp/v2/tags",
         headers=self.wp_header,
         json={"name": tag_name},
+        timeout=DEFAULT_TIMEOUT,
     )
     if resp.status_code == 201:
         payload = resp.json()

--- a/m2w/rest_api/tags.py
+++ b/m2w/rest_api/tags.py
@@ -4,27 +4,28 @@
 # @Author  : Suzuran
 # @FileName: tags.py
 # @Software: PyCharm
-import re
 
+import asyncio
 import httpx
 import math
-import asyncio
+
+from .utils import format_wp_error, register_taxonomy_alias
+
+
+def _cache_tag_aliases(store, payload) -> None:
+    tag_id = int(payload["id"])
+    register_taxonomy_alias(store, tag_id, payload.get("name"), payload.get("slug"))
 
 
 async def __tags_request(self, client: httpx.AsyncClient(), page_num: int):
     resp = await client.get(
         self.url + f"wp-json/wp/v2/tags?page={page_num}&per_page=30"
     )
-    try:
-        assert (
-            resp.status_code == 200
-        ), "Error when requiring tag lists. Pleas try later!"
-    except AssertionError as e:
-        print("Reminder from Bensz(https://blognas.hwb0307.com) : " + str(e))
-        raise AssertionError
+    if resp.status_code != 200:
+        raise RuntimeError(f"Error when requiring tag lists: {format_wp_error(resp)}")
 
-    for tags in resp.json():
-        self.tags_dict[tags['name']] = tags['id']
+    for tag in resp.json():
+        _cache_tag_aliases(self.tags_dict, tag)
 
 
 async def get_all_tags(self, verbose) -> None:
@@ -53,17 +54,28 @@ def create_tag(self, tag_name: str) -> int:
     @param tag_name: 标签名
     @return: 创建tag的id
     """
-    try:
-        resp = httpx.post(
-            url=self.url + "wp-json/wp/v2/tags",
-            headers=self.wp_header,
-            json={"name": tag_name},
-        )
-        assert (
-            resp.status_code == 201
-        ), f"Tag created failed. Please try again! Messages:{resp.json()['message']}"
-        self.tags_dict[tag_name] = resp.json()["id"]
-        return resp.json()['id']
-    except AssertionError as e:
-        print("Reminder from m2w: " + str(e))
-        raise AssertionError
+    resp = httpx.post(
+        url=self.url + "wp-json/wp/v2/tags",
+        headers=self.wp_header,
+        json={"name": tag_name},
+    )
+    if resp.status_code == 201:
+        payload = resp.json()
+        tag_id = int(payload['id'])
+        _cache_tag_aliases(self.tags_dict, payload)
+        register_taxonomy_alias(self.tags_dict, tag_id, tag_name)
+        return tag_id
+
+    if resp.status_code == 400:
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict) and payload.get("code") == "term_exists":
+            term_id = payload.get("data", {}).get("term_id")
+            if term_id is not None:
+                term_id = int(term_id)
+                register_taxonomy_alias(self.tags_dict, term_id, tag_name)
+                return term_id
+
+    raise RuntimeError(f"Tag created failed: {format_wp_error(resp)}")

--- a/m2w/rest_api/update.py
+++ b/m2w/rest_api/update.py
@@ -8,7 +8,7 @@
 from .categories import create_category
 from .tags import create_tag
 from .articles import normalize_title
-from .utils import lookup_taxonomy_id, ensure_wp_success
+from .utils import lookup_taxonomy_id, ensure_wp_success, DEFAULT_TIMEOUT
 import frontmatter
 import markdown
 import os
@@ -85,5 +85,6 @@ def _update_article(self, md_path, post_metadata, last_update=False) -> None:
         + f"wp-json/wp/v2/posts/{self.article_title_dict[filename_prefix]}",
         headers=self.wp_header,
         json=post_data,
+        timeout=DEFAULT_TIMEOUT,
     )
     ensure_wp_success(resp, f"File {md_path} updated")

--- a/m2w/rest_api/utils.py
+++ b/m2w/rest_api/utils.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+"""WordPress REST API utility helpers."""
+
+import unicodedata
+from typing import Dict, Optional
+
+
+def format_wp_error(response) -> str:
+    """Return a readable error string extracted from a WordPress REST response."""
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+
+    details = []
+    if isinstance(payload, dict):
+        message = payload.get("message")
+        code = payload.get("code")
+        data = payload.get("data")
+        if isinstance(message, str) and message.strip():
+            details.append(message.strip())
+        elif code:
+            details.append(str(code))
+        if isinstance(data, dict):
+            status = data.get("status")
+            term_id = data.get("term_id")
+            extra = []
+            if status:
+                extra.append(f"status={status}")
+            if term_id:
+                extra.append(f"term_id={term_id}")
+            if extra:
+                details.append(", ".join(extra))
+    elif isinstance(payload, list):
+        details.append(str(payload))
+    else:
+        text = response.text.strip()
+        if text:
+            details.append(text)
+
+    if not details:
+        details.append("WordPress response contained no details.")
+    return f"HTTP {response.status_code}: {'; '.join(details)}"
+
+
+def normalize_taxonomy_key(value: Optional[str]) -> Optional[str]:
+    """Normalize taxonomy name/slug for alias mapping."""
+    if not isinstance(value, str):
+        return None
+    normalized = unicodedata.normalize("NFKC", value).strip()
+    if not normalized:
+        return None
+    return normalized.casefold()
+
+
+def register_taxonomy_alias(store: Dict[str, int], term_id: int, *aliases: Optional[str]) -> None:
+    """Register multiple aliases pointing to the same taxonomy id."""
+    for alias in aliases:
+        normalized = normalize_taxonomy_key(alias)
+        if normalized:
+            store[normalized] = term_id
+
+
+def lookup_taxonomy_id(store: Dict[str, int], name: str) -> Optional[int]:
+    """Return cached taxonomy id that matches the provided name/slug."""
+    normalized = normalize_taxonomy_key(name)
+    if not normalized:
+        return None
+    return store.get(normalized)
+
+
+def ensure_wp_success(response, action: str) -> None:
+    """Raise RuntimeError when the HTTP response indicates failure."""
+    if not (200 <= response.status_code < 300):
+        raise RuntimeError(f"{action} failed: {format_wp_error(response)}")

--- a/m2w/rest_api/utils.py
+++ b/m2w/rest_api/utils.py
@@ -2,8 +2,13 @@
 # -*- coding: utf-8 -*-
 """WordPress REST API utility helpers."""
 
+import httpx
 import unicodedata
 from typing import Dict, Optional
+
+
+# Use a generous default timeout because some WordPress hosts respond slowly.
+DEFAULT_TIMEOUT = httpx.Timeout(30.0)
 
 
 def format_wp_error(response) -> str:

--- a/m2w/up.py
+++ b/m2w/up.py
@@ -1,102 +1,205 @@
 
 
+
+
 from m2w.rest_api import RestApi
+
 from m2w.up_password import md_detect, up_password
+
 from m2w.wp import wp_xmlrpc
+
 import sys
+
 import os
+
 import shutil
 
+
+
 async def up(
+
         path_markdown, 
+
         path_legacy_json,
+
         domain, username, password, application_password, post_metadata,
+
         last_update_time_change = False, force_upload=False, verbose=True, rest_api=True, max_retries = 10
+
         ):
+
     
+
     """
+
     ### Description
+
     Upload or update markdown files to your WordPress site.
 
+
+
     ### Parameters
+
     + path_markdown: The path of markdown files
+
     + path_legacy_json: The path of legacy*.json
+
     + domain, username, password, application_password, post_metadata: The data of a WordPress website
+
     + last_update_time_change: Boolean. Whether to update the last update time of the post. Only work in REST API mode
+
     + force_upload: Boolean. Whether check the existence of a new post before uploading. Default is False, which means that every new post would receive checking
+
     + verbose: Boolean. Whether output running messages of the function
+
     + rest_api: Whether to use REST API mode
+
     + max_retries: Integer. The max retry time when meeting failure
 
+
+
     ### Return
+
     None
+
     """
 
+
+
     # Backup old legacy*.json
+
     is_first_legacy_exist = os.path.exists(path_legacy_json)
+
     if is_first_legacy_exist:
+
         shutil.copyfile(path_legacy_json, path_legacy_json + "_temporary_old")
+
+
 
     # Mode
+
     if rest_api:
+
         # REST API Mode
+
         if verbose:
+
             print("(ฅ´ω`ฅ) REST API Mode. Very safe!")
+
         rest = RestApi(
+
             url=domain, wp_username=username, wp_password=application_password
+
         )
+
     else:
+
         # Legacy Password Mode
+
         if verbose:
+
             print("Σ( ° △ °|||)︴Legacy Password Mode. Not safe!")
+
         client = wp_xmlrpc(domain, username, password)
+
     
+
     # Gather paths of brand-new and changed legacy markdown files
+
     res = md_detect(path_markdown, path_legacy_json, verbose=verbose)
+
     md_upload = res["new"]
+
     md_update = res["legacy"]
 
+
+
     # Backup the latest legacy*.json
+
     shutil.copyfile(path_legacy_json, path_legacy_json + "_temporary_latest")
+
     if not is_first_legacy_exist:
+
         shutil.copyfile(path_legacy_json, path_legacy_json + "_temporary_old")
 
+
+
     # Upload & Update
+
     if len(md_upload) > 0 or len(md_update) > 0:
+
         for retry in range(max_retries):
+
             try:
+
                 if rest_api:
+
                     # Use REST API mode to upload/update articles
+
                     await rest.upload_article(
+
                         md_message=res,
+
                         post_metadata=post_metadata,
+
                         verbose=verbose,
+
                         force_upload=force_upload,
+
                         last_update=last_update_time_change,
+
                     )
+
                 else:
+
                     # Use Password mode to upload/update articles
+
                     up_password(
+
                         client,
+
                         md_upload,
+
                         md_update,
+
                         post_metadata,
+
                         force_upload=force_upload,
+
                         verbose=verbose,
+
                     )
+
                 if os.path.exists(path_legacy_json + "_temporary_latest"):
+
                     shutil.copyfile(path_legacy_json + "_temporary_latest", path_legacy_json)     
+
                 break
+
             except Exception as e:
+
                 print("OOPS, the upload/update process failed!")
+
+                print(f"{e.__class__.__name__}: {e}")
+
                 if os.path.exists(path_legacy_json + "_temporary_old"):
+
                     shutil.copyfile(path_legacy_json + "_temporary_old", path_legacy_json)
+
                 if retry < max_retries - 1:
+
                     print("Retrying...")
+
                     continue
+
                 else:
+
                     print("Maximum retries exceeded. Exiting.")
+
                     sys.exit(0)
+
     else:
+
         if verbose:
+
             print("Without any new or changed legacy markdown files. Ignored.")

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,15 @@ from setuptools import setup, find_packages
 
 + 输入"pip install twine"来安装twine工具。 必要时可更新工具包：pip install --upgrade twine setuptools wheel
 
-+ 使用"python setup.py sdist"命令来生成项目的源代码包。 如果要测试该包，可运行类似命令： python setup.py sdist; pip install .\dist\m2w-2.5.13.tar.gz
++ 使用"python setup.py sdist"命令来生成项目的源代码包。 如果要测试该包，可运行类似命令： 
+  + Windows: python setup.py sdist; pip install .\dist\m2w-2.5.14.tar.gz
+  + macOS: python setup.py sdist; pip install ./dist/m2w-2.5.14.tar.gz
+
++ 确定目前的测试是最新的版本： pip show m2w | grep Version
 
 + 使用"python setup.py bdist_wheel"命令来生成项目的长描述。
 
-+ 上传至PyPi。输入"twine upload dist/*2.5.13* --verbose"来上传项目的源代码包。
++ 上传至PyPi。输入"twine upload dist/*2.5.14* --verbose"来上传项目的源代码包。
 
 + 在上传过程中，你需要输入你在PyPi上注册的用户名和密码。
 
@@ -42,12 +46,12 @@ from setuptools import setup, find_packages
 
 ### How to install
 + pip install --upgrade -i https://pypi.org/simple m2w 
-+ pip install -i https://pypi.org/simple m2w==2.5.13
++ pip install -i https://pypi.org/simple m2w==2.5.14
 + pip install m2w 
 
 """
 
-VERSION = "2.5.13"
+VERSION = "2.5.14"
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## 问题描述

修复 #26 

在 REST API 模式下更新已有文章时，程序会陷入无限重试循环，控制台不断输出 "Retrying..."。

## 问题原因

1. **标题匹配缺失 `normalize_title` 处理**：`update.py` 中使用文件名查找 `article_title_dict` 时，未对文件名进行标准化处理，导致 `KeyError`

2. **Taxonomy 缓存键不统一**：`tags_dict` 和 `categories_dict` 的键值未标准化（大小写、slug、别名等），导致查找时无法命中缓存

3. **`term_exists` 错误未正确处理**：当尝试创建已存在的 tag/category 时，WordPress 返回 HTTP 400 和 `term_exists` 错误码，但原代码直接抛出异常而非复用服务器返回的 `term_id`

4. **异常信息不够详细**：`up.py` 捕获异常后仅输出 \"OOPS, the upload/update process failed!\"，未显示具体错误类型和消息

## 修复内容

### 新增文件
- `m2w/rest_api/utils.py`：集中提供辅助函数
  - `format_wp_error()`: 解析 WordPress REST API 错误响应
  - `normalize_taxonomy_key()`: 标准化 taxonomy 名称/slug
  - `register_taxonomy_alias()`: 注册 taxonomy 别名到缓存
  - `lookup_taxonomy_id()`: 查找 taxonomy ID
  - `ensure_wp_success()`: 统一检查 HTTP 响应状态

### 修改文件
- `m2w/rest_api/update.py`: 使用 `normalize_title` 处理文件名，使用 `lookup_taxonomy_id` 查缓存
- `m2w/rest_api/create.py`: 与更新逻辑保持一致
- `m2w/rest_api/tags.py`: 抓取列表时缓存名称和 slug 别名，处理 `term_exists` 错误复用 `term_id`
- `m2w/rest_api/categories.py`: 同 tags.py
- `m2w/up.py`: 输出详细的异常类型和消息 `{e.__class__.__name__}: {e}`

## 验证

```bash
# 语法检查
python -m compileall m2w/rest_api  # 通过

# 实际测试
python myblog.py
```

修复后输出：
```
========Website: ssbx
(ฅ´ω`ฅ) REST API Mode. Very safe!
With legacy.json. Confirm new or changed legacy markdown files.
No new markdown files. Ignored.
Content changed!:  C:/Users/Administrator/developments/php/blog/ssbx\test.md
Get tag lists complete!
Get category lists complete!
Get article lists complete!
You don't want a force uploading. The existence of the post would be checked.
The post C:/Users/Administrator/developments/php/blog/ssbx\test.md updates successful!
All done! Total time : 15.241s
```